### PR TITLE
feat: Events V2 Phase 4 - Interactive Location Selection UI

### DIFF
--- a/commands/events.js
+++ b/commands/events.js
@@ -484,8 +484,9 @@ module.exports = {
             .addComponents(
                 // Button to trigger a modal for basic info (title, desc, date, time) - Future Step
                 // new ButtonBuilder().setCustomId(`edit-event-basic-${eventId}`).setLabel('Edit Basic Info').setStyle(1),
+                new ButtonBuilder().setCustomId(`edit-location-${eventId}`).setLabel('Change Location').setStyle(1), // Primary style for location
                 new ButtonBuilder().setCustomId(`manage-custom-fields-${eventId}`).setLabel('Manage Custom Fields').setStyle(2),
-                new ButtonBuilder().setCustomId(`manage-event-rewards-${eventId}`).setLabel('Manage Rewards').setStyle(2), // New Button
+                new ButtonBuilder().setCustomId(`manage-event-rewards-${eventId}`).setLabel('Manage Rewards').setStyle(2),
                 new ButtonBuilder().setCustomId(`edit-event-image-${eventId}`).setLabel('Change Image').setStyle(2)
             );
 

--- a/utils/gameData.js
+++ b/utils/gameData.js
@@ -1,0 +1,10 @@
+const ISLAND_DATA = {
+  "Desert": { areas: ["Area 1 (Desert)", "Area 2 (Desert)", "Area 3 (Desert)"], emoji: "🏜️" },
+  "Tropical": { areas: ["Area A (Tropics)", "Area B (Tropics)", "Area C (Tropics)", "Area D (Tropics)"], emoji: "🏝️" },
+  "Snow": { areas: ["Zone Alpha (Snow)", "Zone Beta (Snow)"], emoji: "❄️" },
+  "Volcano": { areas: ["Crater Rim (Volcano)", "Lava Tubes (Volcano)", "Ash Fields (Volcano)"], emoji: "🌋" }
+};
+
+module.exports = {
+    ISLAND_DATA,
+};


### PR DESCRIPTION
- Centralize ISLAND_DATA into utils/gameData.js and update imports.
- Enhance event creation flow (modal handler in index.js):
  - If location (island/area) is not set by a template, the bot now replies with a StringSelectMenu for island selection.
- Implement StringSelectMenu handlers in index.js:
  - 'select-island-<eventId>': Sets the island and presents an area selection menu for that island.
  - 'select-area-<eventId>-<islandName>': Sets the area and confirms the location selection.
- Update '/events edit' command:
  - Add a 'Change Location' button to its response.
  - Implement a button handler in index.js for 'edit-location-<eventId>' that initiates the island/area selection flow.
- Reviewed buildEventEmbed to ensure graceful handling of potentially null location data.