### PR TITLE
Fix: Correct error handling in events command

### DIFF
--- a/commands/events.js
+++ b/commands/events.js
@@ -588,9 +588,14 @@ module.exports = {
           .setColor(0xE53935) // ERROR_COLOR
           .setTitle('⚠️ Internal Error')
           .setDescription('An unexpected error occurred while processing the command. Please try again later or contact an administrator.');
-        return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
-      } catch {
-        /* ignore secondary failures */
+        if (interaction.deferred || interaction.replied) {
+          return interaction.followUp({ embeds: [errorEmbed], ephemeral: true });
+        } else {
+          return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
+        }
+      } catch (secondaryError) {
+        console.error('💥 Error in /events command secondary error handler:', secondaryError);
+        /* ignore secondary failures, but log them */
       }
     }
   },


### PR DESCRIPTION
Modified the error handling within the main try/catch block of the events command to prevent 'Interaction has already been acknowledged' errors.

The handler now checks if the interaction was previously deferred or replied to.
- If so, it uses `followUp` to send an error message.
- Otherwise, it uses `reply`.

This ensures that a response is not attempted on an already acknowledged interaction, which was causing a secondary error and preventing a clean error message to the user.