### PR TITLE
feat: Implement /manage command for comprehensive bot administration

### DIFF
--- a/commands/manage.js
+++ b/commands/manage.js
@@ -1,0 +1,47 @@
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, PermissionFlagsBits } = require('discord.js');
+const { isBotAdmin } = require('../utils/permissions'); // Assuming this path is correct
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('manage')
+    .setDescription('Access the management panel for bot settings.')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator), // Default for admins, but will also check custom isBotAdmin
+
+  async execute(interaction, linkStore, envConfig) {
+    // Check if the user is a bot admin (includes owner)
+    if (!isBotAdmin(interaction.member, envConfig.ADMIN_ROLES, envConfig.OWNER_ID)) {
+      const noPermsEmbed = new EmbedBuilder()
+        .setColor(0xE53935) // ERROR_COLOR
+        .setTitle('🚫 Permission Denied')
+        .setDescription('You do not have the required permissions (Bot Admin or Owner) to use this command.');
+      return interaction.reply({ embeds: [noPermsEmbed], ephemeral: true });
+    }
+
+    const manageEmbed = new EmbedBuilder()
+      .setColor(0x0099FF) // INFO_COLOR or a custom one
+      .setTitle('🛠️ Bot Management Panel')
+      .setDescription('Welcome to the Bot Management Panel. Please choose an option below to configure settings.')
+      .setTimestamp();
+
+    const row = new ActionRowBuilder()
+      .addComponents(
+        new ButtonBuilder()
+          .setCustomId('manage_bot_moderators')
+          .setLabel('Manage Bot Moderators')
+          .setStyle(ButtonStyle.Primary)
+          .setEmoji('🛡️'),
+        new ButtonBuilder()
+          .setCustomId('manage_event_reward_types')
+          .setLabel('Manage Event Reward Types')
+          .setStyle(ButtonStyle.Primary)
+          .setEmoji('🎁'),
+        new ButtonBuilder()
+          .setCustomId('manage_rsvp_role')
+          .setLabel('Manage RSVP Role')
+          .setStyle(ButtonStyle.Primary)
+          .setEmoji('🎟️')
+      );
+
+    await interaction.reply({ embeds: [manageEmbed], components: [row], ephemeral: true });
+  },
+};

--- a/utils/idGenerator.js
+++ b/utils/idGenerator.js
@@ -22,6 +22,22 @@ function generateEventId() {
   return result;
 }
 
+/**
+ * Generates a random 8-character string for reward types.
+ * Similar to generateEventId but uses a slightly different length for potential distinction.
+ * @returns {string} An 8-character random alphanumeric ID.
+ */
+function generateRewardTypeId() {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  const randomBytes = crypto.randomBytes(8);
+  for (let i = 0; i < 8; i++) {
+    result += chars[randomBytes[i] % chars.length];
+  }
+  return result;
+}
+
 module.exports = {
   generateEventId,
+  generateRewardTypeId,
 };


### PR DESCRIPTION
This commit introduces the new `/manage` slash command, providing a centralized panel for bot owners and admins to configure various aspects of the bot.

Key features include:
- A main management menu triggered by `/manage`.
- Guidance to use `/managemod` for bot moderator management.
- Full CRUD functionality for Global Event Reward Types:
    - Admins can create, list, edit, and delete predefined reward types.
    - These global types can be used as templates when adding rewards to specific events via the event editing flow (e.g., `/events edit` -> Manage Rewards -> Add From Predefined).
- RSVP Role Configuration:
    - Admins can set, change, view, and clear a specific Discord role.
    - This configured role is automatically assigned to users when they RSVP "Going" to an event and removed if they RSVP "Can't Go".

Backend changes include:
- New database tables/collections for `global_reward_types` and `rsvp_role_config` (for both SQLite and MongoDB).
- New `linkStore` methods to support these features.
- Updated ID generation for reward types.

Interaction handlers in `index.js` have been significantly expanded to support the new buttons, modals, and select menus introduced by the `/manage` command and its sub-features.