### PR TITLE
feat: Rework event rewards to link to global types with icons and qua…

### DIFF
--- a/commands/events.js
+++ b/commands/events.js
@@ -699,15 +699,33 @@ function buildEventEmbed(event, envConfig) { // envConfig might be useful for gl
     });
   }
 
-  // Event Rewards display
+  // Event Rewards display (now uses linked global rewards with quantity)
   if (event.rewards && event.rewards.length > 0) {
     embed.addFields({ name: '\u200B', value: '**🎁 Event Rewards:**' }); // Separator
     event.rewards.forEach(reward => {
-      let rewardValue = reward.description || '_No description_';
-      if (reward.image_url) { // Simple link for now, not inline image in field
-        rewardValue += `\n[View Image](${reward.image_url})`;
+      let rewardNameDisplay = reward.name || 'Unknown Reward';
+      if (reward.icon_url) {
+        // Check if icon_url is a standard emoji
+        if (reward.icon_url.match(/^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F)$/u)) {
+          rewardNameDisplay = `${reward.icon_url} ${rewardNameDisplay}`;
+        } else {
+          // For URLs, we might not be able to display an image inline in a field name/value easily.
+          // We can prepend a generic icon or link it in the value.
+          // For now, let's just indicate an icon is present if it's a URL.
+          rewardNameDisplay = `🖼️ ${rewardNameDisplay}`; // Generic picture emoji
+        }
       }
-      embed.addFields({ name: reward.name, value: rewardValue, inline: event.rewards.length > 1 }); // Inline if multiple rewards
+
+      let rewardValue = `Quantity: ${reward.quantity}`;
+      if (reward.description) {
+        rewardValue += `\n*${reward.description.substring(0, 200)}*`; // Show description, truncated
+      }
+      // If icon_url is a URL and we want to link it:
+      // if (reward.icon_url && !reward.icon_url.match(/^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F)$/u)) {
+      //   rewardValue += `\n[Icon URL](${reward.icon_url})`;
+      // }
+
+      embed.addFields({ name: rewardNameDisplay, value: rewardValue, inline: event.rewards.length > 2 ? true : false });
     });
   }
 


### PR DESCRIPTION
…ntities

This commit significantly overhauls the event reward system and introduces icon support for global reward types.

Key Changes:

1.  **Global Reward Types (`/manage`):**
    *   Can now have an `icon_url` (or emoji) specified during creation/editing.
    *   List view displays this icon information.

2.  **Event Rewards System (Linked Model):**
    *   `event_rewards` in the database no longer store individual name/description/image but now link to a `global_reward_type_id` and store a `quantity`.
    *   `linkStore` methods for event rewards are updated:
        *   `addEventReward` replaced by `linkEventReward(eventId, globalRewardTypeId, quantity)`.
        *   `getEventRewards(eventId)` now performs a JOIN/lookup to fetch global reward details (name, description, icon) and the event-specific quantity.
        *   `updateEventReward` replaced by `updateEventRewardQuantity(eventSpecificRewardId, quantity)`.
        *   `deleteEventReward` now unlinks the reward from the event.
        *   New `getSpecificEventReward(eventSpecificRewardId)` method added.

3.  **Event Reward Management UI (`/events edit` -> Manage Rewards):**
    *   The UI flow is redesigned. Admins now:
        *   View currently linked rewards for an event.
        *   "Link New Global Reward": Select a global type, then set quantity via a modal.
        *   "Manage Existing Links": For each linked reward, options to "Edit Quantity" (via modal) or "Unlink Reward" (with confirmation).

4.  **Event Display (`buildEventEmbed`):**
    *   Updated to display linked rewards showing the icon (or placeholder), name from global type, and the event-specific quantity.

Backend schemas for `global_reward_types` and `event_rewards` have been updated for both SQLite and MongoDB to support these changes. This change provides a more centralized way to manage reward definitions while allowing per-event quantity customization.